### PR TITLE
Implemented kind-checker

### DIFF
--- a/src/Blob/Inference/AlgorithmW.hs
+++ b/src/Blob/Inference/AlgorithmW.hs
@@ -5,6 +5,8 @@ module Blob.Inference.AlgorithmW
 , tiProgram
 , programTypeInference
 , tiType
+, tiScheme
+, tiCustomType
 , generalize
 ) where
 
@@ -12,10 +14,13 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.MultiMap as MMap
 import Blob.Inference.Types
+import Blob.KindChecking.Checker
+import Blob.KindChecking.Types
 import Blob.Parsing.Types (Expr(..), Literal(..), Statement(..), Program(..), Pattern(..))
 import Blob.PrettyPrinter.PrettyInference (pType)
-import qualified Blob.Parsing.Types as TP (Type(..))
+import qualified Blob.Parsing.Types as TP (Type(..), Scheme(..), CustomType(..))
 import Control.Monad (zipWithM, foldM)
+import Control.Monad.Trans (lift)
 import Control.Monad.State (runState, get, put, modify, runStateT)
 import Control.Monad.Reader (runReaderT, ask, local)
 import Control.Monad.Except (runExceptT, throwError, runExcept)
@@ -152,10 +157,19 @@ makeRedefinedError id' = text "Symbol “" <> text id' <> text "” already defi
 tiType :: TP.Type -> Type
 tiType (TP.TId id')        = TId id'
 tiType (TP.TArrow _ t1 t2) = TFun (tiType t1) (tiType t2)
+tiType (TP.TFun t1 t2)     = TFun (tiType t1) (tiType t2)
 tiType (TP.TTuple ts)      = TTuple (map tiType ts)
 tiType (TP.TVar id')       = TRigidVar id'
 tiType (TP.TList t)        = TList (tiType t)
 tiType (TP.TApp t1 t2)     = TApp (tiType t1) (tiType t2)
+
+tiScheme :: TP.Scheme -> Scheme
+tiScheme (TP.Scheme tvs t) = Scheme tvs (tiType t)
+
+tiCustomType :: TP.CustomType -> CustomType
+tiCustomType (TP.TSum cs)   = TSum (fmap tiScheme cs)
+tiCustomType (TP.TProd c s) = TProd c (tiScheme s)
+tiCustomType (TP.TAlias t)  = TAlias (tiType t)
 
 sepStatements :: [Statement] -> Check ()
 sepStatements s = do
@@ -222,10 +236,19 @@ sepStatements s = do
     separateDecls (Definition id' expr : stmts)   = second ((id', expr):) (separateDecls stmts)
     separateDecls (_ : stmts)                     = separateDecls stmts
 
+analyseTypeDecl :: String -> CustomScheme -> Check ()
+analyseTypeDecl k v = do
+    kind <- checkKI $ do
+        var        <- newKindVar "r"
+        (subst, t) <- local (Map.insert k var) (kiCustomScheme v)
+        subst1     <- mguKind (applyKind subst var) (applyKind subst t)
+        pure $ applyKind (subst1 `composeKindSubst` subst) var
+    modify $ \st -> st { typeDefCtx  = Map.insert k v (typeDefCtx st)
+                       , typeDeclCtx = Map.insert k kind (typeDeclCtx st) }
 
 checkTI :: TI a -> Check a
 checkTI ti = do
-    (GlobalEnv declEnv defEnv) <- get
+    (GlobalEnv _ _ declEnv defEnv) <- get
 
     let (TypeEnv e1_) = declEnv
         (TypeEnv e2_) = defEnv
@@ -237,7 +260,14 @@ checkTI ti = do
         Right result -> pure result
 
 tiProgram :: Program -> Check ()
-tiProgram (Program stmts) = sepStatements stmts
+tiProgram (Program stmts) = do
+    remaining <- sepTypeDecls stmts
+    sepStatements remaining
+  where sepTypeDecls [] = pure []
+        sepTypeDecls (TypeDeclaration k tvs t:ss) = do
+            analyseTypeDecl k (CustomScheme tvs (tiCustomType t))
+            sepTypeDecls ss
+        sepTypeDecls (s:ss) = (s:) <$> sepTypeDecls ss
 
 programTypeInference :: GlobalEnv -> Check a -> Either TIError (a, GlobalEnv)
 programTypeInference g p = runExcept (runStateT p g)

--- a/src/Blob/Inference/AlgorithmW.hs
+++ b/src/Blob/Inference/AlgorithmW.hs
@@ -11,7 +11,7 @@ module Blob.Inference.AlgorithmW
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.MultiMap as MMap
-import Blob.Inference.Types (Type(..), Subst, Scheme(..), TypeEnv(..), TIError, TI, TIState(..), Types(..), Check, GlobalEnv(..))
+import Blob.Inference.Types
 import Blob.Parsing.Types (Expr(..), Literal(..), Statement(..), Program(..), Pattern(..))
 import Blob.PrettyPrinter.PrettyInference (pType)
 import qualified Blob.Parsing.Types as TP (Type(..))
@@ -22,24 +22,6 @@ import Control.Monad.Except (runExceptT, throwError, runExcept)
 import Text.PrettyPrint.Leijen (text, dot, linebreak)
 import Data.Bifunctor (bimap, first, second)
 import Data.Maybe (isJust)
-
-nullSubst :: Subst
-nullSubst = mempty
-
-composeSubst :: Subst -> Subst -> Subst
-composeSubst s1 s2 = Map.map (apply s1) s2 `Map.union` s1
-
-remove :: TypeEnv -> String -> TypeEnv
-remove (TypeEnv env) var = TypeEnv (Map.delete var env)
-
-insert :: String -> Scheme -> TypeEnv -> TypeEnv
-insert k v (TypeEnv env) = TypeEnv $ Map.insert k v env
-
-lookup' :: TypeEnv -> String -> Maybe Scheme
-lookup' (TypeEnv env) n = Map.lookup n env
-
-getScheme :: String -> TypeEnv -> Maybe Scheme
-getScheme k (TypeEnv env) = env Map.!? k
 
 generalize :: TypeEnv -> Type -> Scheme
 generalize env t = Scheme vars t

--- a/src/Blob/Inference/Types.hs
+++ b/src/Blob/Inference/Types.hs
@@ -23,6 +23,15 @@ data Type = TVar String
           | TId String
     deriving (Eq, Ord, Show)
 
+data Kind = KType | KArr Kind Kind | KVar String
+    deriving (Eq)
+
+data CustomType = TSum (Map.Map String Scheme) | TProd String Scheme | TAlias Type
+    deriving (Eq, Ord, Show)
+
+data CustomScheme = CustomScheme [String] CustomType
+    deriving (Eq, Ord, Show)
+
 type TIError = Doc
 
 data Scheme = Scheme [String] Type
@@ -30,6 +39,9 @@ data Scheme = Scheme [String] Type
 
 newtype TypeEnv = TypeEnv (Map.Map String Scheme)
     deriving Show
+
+type KindEnv = Map.Map String Kind
+type CustomTypeEnv = Map.Map String CustomScheme
 
 type Subst = Map.Map String Type
 
@@ -39,7 +51,11 @@ data TIState = TIState
 
 type TI a = ExceptT TIError (ReaderT TypeEnv (State TIState)) a
 
-data GlobalEnv = GlobalEnv { declCtx :: TypeEnv, defCtx :: TypeEnv }
+data GlobalEnv = GlobalEnv
+    { typeDeclCtx :: KindEnv
+    , typeDefCtx  :: CustomTypeEnv
+    , declCtx     :: TypeEnv
+    , defCtx      :: TypeEnv }
 
 type Check a = StateT GlobalEnv (Except TIError) a
 

--- a/src/Blob/Inference/Types.hs
+++ b/src/Blob/Inference/Types.hs
@@ -43,6 +43,24 @@ data GlobalEnv = GlobalEnv { declCtx :: TypeEnv, defCtx :: TypeEnv }
 
 type Check a = StateT GlobalEnv (Except TIError) a
 
+nullSubst :: Subst
+nullSubst = mempty
+
+composeSubst :: Subst -> Subst -> Subst
+composeSubst s1 s2 = Map.map (apply s1) s2 `Map.union` s1
+
+remove :: TypeEnv -> String -> TypeEnv
+remove (TypeEnv env) var = TypeEnv (Map.delete var env)
+
+insert :: String -> Scheme -> TypeEnv -> TypeEnv
+insert k v (TypeEnv env) = TypeEnv $ Map.insert k v env
+
+lookup' :: TypeEnv -> String -> Maybe Scheme
+lookup' (TypeEnv env) n = Map.lookup n env
+
+getScheme :: String -> TypeEnv -> Maybe Scheme
+getScheme k (TypeEnv env) = env Map.!? k
+
 ----------------------------------------------------------------------------------------------
 instance Types Type where
     ftv (TVar n)      = Set.singleton n

--- a/src/Blob/KindChecking/Checker.hs
+++ b/src/Blob/KindChecking/Checker.hs
@@ -1,6 +1,76 @@
+{-# LANGUAGE TupleSections #-}
+
 module Blob.KindChecking.Checker where
 
-import qualified Blob.Inference.Types as IT (Type(..))
-import qualified Blob.Parsing.Types as PT (Type(..))
-import Blob.KindChecking.Types (Kind(..))
+import Blob.Inference.Types
+import qualified Blob.Parsing.Types as PT
+import Blob.KindChecking.Types
 
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import Control.Monad.State
+import Control.Monad.Reader
+import Control.Monad.Except
+
+import Text.PrettyPrint.Leijen (text, (<+>))
+
+nullKindSubst :: KindSubst
+nullKindSubst = mempty
+
+composeKindSubst :: KindSubst -> KindSubst -> KindSubst
+composeKindSubst s1 s2 = Map.map (applyKind s1) s2 `Map.union` s1
+
+concatKindSubsts :: [KindSubst] -> KindSubst
+concatKindSubsts = foldr composeKindSubst nullKindSubst
+
+runKI :: TypeEnv -> KI a -> (Either KIError a, KIState)
+runKI env t = runState (runReaderT (runExceptT t) mempty) initKIState
+  where initKIState = KIState { kiSupply  = 0
+                              , kiTypeEnv = env }
+
+newKindVar :: String -> KI Kind
+newKindVar prefix = do
+    s <- get
+    put s { kiSupply = kiSupply s + 1 }
+    pure $ KVar (prefix ++ show (kiSupply s))
+
+mguKind :: Kind -> Kind -> KI KindSubst
+mguKind KType KType = pure nullKindSubst
+mguKind (KArr l r) (KArr l' r') = do
+    s1 <- mguKind l l'
+    s2 <- mguKind (applyKind s1 r) (applyKind s1 r')
+    pure $ s1 `composeKindSubst` s2
+
+kiType :: Type -> KI (KindSubst, Kind)
+kiType (TId n) = gets (getScheme n . kiTypeEnv) >>= maybe err kiScheme
+    where err = throwError (text "Undefined type" <+> text n)
+kiType (TVar n) = asks (Map.lookup n) >>= maybe err (pure . (mempty,))
+    where err = throwError (text "Unbound type variable" <+> text n)
+kiType (TTuple []) = pure (mempty, KType)
+kiType (TTuple (t:ts)) = do
+    (s1, k) <- kiType t
+    s2 <- mguKind k KType
+    (s3, _) <- kiType (TTuple ts) 
+    pure (concatKindSubsts [s3,s2,s1], KType)
+kiType (TFun t1 t2) = do
+    (s1, k1) <- kiType t1
+    (s2, k2) <- kiType t1
+    s3 <- mguKind k1 KType
+    s4 <- mguKind k2 KType
+    pure (concatKindSubsts [s4,s3,s2,s1], KType)
+kiType (TList t) = do
+    (s1, k) <- kiType t
+    s2 <- mguKind k KType
+    pure (s2 `composeKindSubst` s1, KType)
+kiType (TApp f t) = do
+    kv       <- newKindVar "k"
+    (s1, k1) <- kiType f
+    (s2, k2) <- local (applyKind s1 <$>) (kiType t)
+    s3       <- mguKind (applyKind s2 k1) (KArr k2 kv)
+    pure (s3 `composeKindSubst` s2 `composeKindSubst` s1, applyKind s3 kv)
+
+kiScheme :: Scheme -> KI (KindSubst, Kind)
+kiScheme (Scheme vars t) = do
+    nvars <- mapM (\_ -> newKindVar "k") vars
+    let s = Map.fromList (zip vars nvars)
+    local (Map.union s) (kiType t)

--- a/src/Blob/KindChecking/Checker.hs
+++ b/src/Blob/KindChecking/Checker.hs
@@ -1,18 +1,22 @@
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TupleSections, LambdaCase #-}
 
 module Blob.KindChecking.Checker where
 
 import Blob.Inference.Types
 import qualified Blob.Parsing.Types as PT
 import Blob.KindChecking.Types
+import Blob.PrettyPrinter.PrettyInference (pType, pKind)
 
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import Data.Maybe (fromJust, maybe)
 import Control.Monad.State
 import Control.Monad.Reader
 import Control.Monad.Except
 
-import Text.PrettyPrint.Leijen (text, (<+>))
+import Text.PrettyPrint.Leijen (text, (<+>), linebreak, dot)
+
+import Debug.Trace
 
 nullKindSubst :: KindSubst
 nullKindSubst = mempty
@@ -23,10 +27,9 @@ composeKindSubst s1 s2 = Map.map (applyKind s1) s2 `Map.union` s1
 concatKindSubsts :: [KindSubst] -> KindSubst
 concatKindSubsts = foldr composeKindSubst nullKindSubst
 
-runKI :: TypeEnv -> KI a -> (Either KIError a, KIState)
-runKI env t = runState (runReaderT (runExceptT t) mempty) initKIState
-  where initKIState = KIState { kiSupply  = 0
-                              , kiTypeEnv = env }
+runKI :: KindEnv -> KI a -> (Either KIError a, KIState)
+runKI env ki = runState (runReaderT (runExceptT ki) env) initKIState
+  where initKIState = KIState { kiSupply = 0 }
 
 newKindVar :: String -> KI Kind
 newKindVar prefix = do
@@ -34,18 +37,72 @@ newKindVar prefix = do
     put s { kiSupply = kiSupply s + 1 }
     pure $ KVar (prefix ++ show (kiSupply s))
 
+kindVarBind :: String -> Kind -> KI KindSubst
+kindVarBind u k | k == KVar u          = pure nullKindSubst
+                | u `Set.member` fkv k = throwError (makeKindOccurError u k)
+                | otherwise            = pure $ Map.singleton u k
+
 mguKind :: Kind -> Kind -> KI KindSubst
+mguKind (KVar n) k = kindVarBind n k
+mguKind k (KVar n)= kindVarBind n k
 mguKind KType KType = pure nullKindSubst
 mguKind (KArr l r) (KArr l' r') = do
     s1 <- mguKind l l'
     s2 <- mguKind (applyKind s1 r) (applyKind s1 r')
     pure $ s1 `composeKindSubst` s2
+mguKind k1 k2 = throwError (makeKindUnifyError k1 k2)
+
+makeKindUnifyError :: Kind -> Kind -> KIError
+makeKindUnifyError k1 k2 = text "Could not match kinds “" <> pKind k1 <> text "” with “" <> pKind k2 <> text "”" <> dot <> linebreak
+makeKindOccurError :: String -> Kind -> KIError
+makeKindOccurError s k1 = text "Occur check fails: kind " <> text s <> text " vs " <> pKind k1 <> dot <> linebreak
+makeUndefinedTypeError :: String -> KIError
+makeUndefinedTypeError s = text "Undefined kind “" <> text s <> text "”" <> dot <> linebreak
+makeRedeclaredTypeError :: String -> KIError
+makeRedeclaredTypeError id' = text "Type “" <> text id' <> text "” already declared" <> dot <> linebreak
+
+kiCustomScheme :: CustomScheme -> KI (KindSubst, Kind)
+kiCustomScheme (CustomScheme tvs t) = do
+    typeArgs <- Map.fromList <$> mapM (\ v -> (v,) <$> newKindVar "k") tvs
+    s <- local (Map.union typeArgs) $ case t of
+        TSum constrs -> kiConstrs (Map.toList constrs)
+        TProd c s -> kiConstrs [(c, s)]
+        _ -> undefined
+    let k = foldr KArr KType (fromJust . flip Map.lookup typeArgs <$> tvs)
+    pure (s, applyKind s k)
+  where foldConstr (TFun t1 t2) = t1 : foldConstr t2
+        foldConstr t = []
+
+        kiConstrs [] = pure nullKindSubst
+        kiConstrs ((n, Scheme _ c):cs) = do
+            s1 <- kiConstr n (foldConstr c)
+            s2 <- kiConstrs cs
+            pure (s2 `composeKindSubst` s1)
+
+        kiConstr n [] = pure nullKindSubst
+        kiConstr n (t:ts) = do
+            (s1, k) <- kiType t
+            s2 <- mguKind k KType
+            s3 <- kiConstr n ts
+            pure (concatKindSubsts [s3,s2,s1])
+
+-- makeFixpoint :: String -> Type -> String -> Type
+-- makeFixpoint n (TId n') v
+--     | n == n'   = v
+--     | otherwise = TId n'
+-- makeFixpoint n (TApp f t) v = TApp (makeFixpoint n f v) (makeFixpoint n t v)
+-- makeFixpoint n (TFun t1 t2) = TFun (makeFixpoint n t1 v) (makeFixpoint n t2 v)
+-- makeFixpoint n (TTuple ts) = TTuple (flip (makeFixpoint n) v <$> ts)
+-- makeFixpoint n (TList t) v = TList (makeFixpoint n t v)
+-- makeFixpoint n t v = t
 
 kiType :: Type -> KI (KindSubst, Kind)
-kiType (TId n) = gets (getScheme n . kiTypeEnv) >>= maybe err kiScheme
-    where err = throwError (text "Undefined type" <+> text n)
+kiType (TId n) = asks (Map.lookup n) >>= maybe err (pure . (mempty,))
+    where err = throwError (makeUndefinedTypeError n)
 kiType (TVar n) = asks (Map.lookup n) >>= maybe err (pure . (mempty,))
-    where err = throwError (text "Unbound type variable" <+> text n)
+    where err = throwError (makeUndefinedTypeError n)
+kiType (TRigidVar n) = asks (Map.lookup n) >>= maybe err (pure . (mempty,))
+    where err = throwError (makeUndefinedTypeError n)
 kiType (TTuple []) = pure (mempty, KType)
 kiType (TTuple (t:ts)) = do
     (s1, k) <- kiType t
@@ -54,7 +111,7 @@ kiType (TTuple (t:ts)) = do
     pure (concatKindSubsts [s3,s2,s1], KType)
 kiType (TFun t1 t2) = do
     (s1, k1) <- kiType t1
-    (s2, k2) <- kiType t1
+    (s2, k2) <- kiType t2
     s3 <- mguKind k1 KType
     s4 <- mguKind k2 KType
     pure (concatKindSubsts [s4,s3,s2,s1], KType)
@@ -67,10 +124,24 @@ kiType (TApp f t) = do
     (s1, k1) <- kiType f
     (s2, k2) <- local (applyKind s1 <$>) (kiType t)
     s3       <- mguKind (applyKind s2 k1) (KArr k2 kv)
-    pure (s3 `composeKindSubst` s2 `composeKindSubst` s1, applyKind s3 kv)
+    pure (concatKindSubsts [s3,s2,s1], applyKind s3 kv)
+kiType t = traceShow t $ undefined
 
 kiScheme :: Scheme -> KI (KindSubst, Kind)
 kiScheme (Scheme vars t) = do
     nvars <- mapM (\_ -> newKindVar "k") vars
     let s = Map.fromList (zip vars nvars)
     local (Map.union s) (kiType t)
+
+checkKI :: KI a -> Check a
+checkKI ki = do
+    (GlobalEnv env _ _ _) <- get
+    let res = runKI env ki
+    case fst res of
+        Left err     -> throwError err
+        Right result -> pure result
+
+kindInference :: TypeEnv -> Type -> KI Kind
+kindInference _ e = do
+    (s, k) <- kiType e
+    pure $ applyKind s k

--- a/src/Blob/KindChecking/Types.hs
+++ b/src/Blob/KindChecking/Types.hs
@@ -1,14 +1,34 @@
 module Blob.KindChecking.Types where
 
+import qualified Data.Map as Map
+import qualified Data.Set as Set
 import Text.PrettyPrint.Leijen (Doc)
-import Control.Monad.State (StateT(..))
-import Control.Monad.Except (Except)
+import Control.Monad.State (State)
+import Control.Monad.Reader (ReaderT)
+import Control.Monad.Except (ExceptT)
+import Data.Maybe (fromMaybe)
 import Blob.Inference.Types (TypeEnv)
 
-data Kind = KType | KArr Kind Kind
+data Kind = KType | KArr Kind Kind | KVar String
 
-type KindEnv = TypeEnv
+type KIError = Doc
 
-type KindError = Doc
+type KindEnv = Map.Map String Kind
 
-type KI a = StateT KindEnv (Except KindError) a
+data KIState = KIState
+    { kiSupply :: Int
+    , kiTypeEnv :: TypeEnv }
+
+type KI a = ExceptT KIError (ReaderT KindEnv (State KIState)) a
+
+type KindSubst = Map.Map String Kind
+
+fkv :: Kind -> Set.Set String
+fkv (KVar n) = Set.singleton n
+fkv (KArr k1 k2) = fkv k1 `Set.union` fkv k2
+fkv KType = mempty
+
+applyKind :: KindSubst -> Kind -> Kind
+applyKind s (KVar n) = fromMaybe (KVar n) (Map.lookup n s)
+applyKind s (KArr k1 k2) = KArr (applyKind s k1) (applyKind s k2)
+applyKind _ KType = KType

--- a/src/Blob/KindChecking/Types.hs
+++ b/src/Blob/KindChecking/Types.hs
@@ -7,17 +7,12 @@ import Control.Monad.State (State)
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.Except (ExceptT)
 import Data.Maybe (fromMaybe)
-import Blob.Inference.Types (TypeEnv)
-
-data Kind = KType | KArr Kind Kind | KVar String
+import Blob.Inference.Types (CustomTypeEnv, Kind(..), KindEnv)
 
 type KIError = Doc
 
-type KindEnv = Map.Map String Kind
-
 data KIState = KIState
-    { kiSupply :: Int
-    , kiTypeEnv :: TypeEnv }
+    { kiSupply :: Int }
 
 type KI a = ExceptT KIError (ReaderT KindEnv (State KIState)) a
 

--- a/src/Blob/Parsing/Parser.hs
+++ b/src/Blob/Parsing/Parser.hs
@@ -5,10 +5,10 @@ module Blob.Parsing.Parser
 , statement
 ) where
 
-import Blob.Parsing.Types (Parser, Program(..), Statement(..), Expr(..), Associativity(..), Fixity(..), CustomOperator(..), ParseState(..), CustomType(..), Type(..))
+import Blob.Parsing.Types (Parser, Program(..), Statement(..), Expr(..), Associativity(..), Fixity(..), CustomOperator(..), ParseState(..), Scheme(..), CustomType(..), Type(..))
 import Blob.Parsing.Lexer (lexeme, lineCmnt, blockCmnt, identifier, parens, opSymbol, symbol, integer, keyword, indented, typeIdentifier, string, typeVariable)
 import Blob.Parsing.ExprParser (expression)
-import Blob.Parsing.TypeParser (type')
+import Blob.Parsing.TypeParser (type', atype')
 import Blob.Parsing.Defaults (addOperator)
 import Text.Megaparsec (many, hidden, some, try, (<|>), (<?>), eof, optional)
 import Text.Megaparsec.Char (eol)
@@ -17,8 +17,6 @@ import Data.Functor(fmap, (<$>), ($>), (<$))
 import Data.Text (pack)
 import Control.Monad.State (lift, modify)
 import qualified Data.Map as Map (fromList)
-import qualified Blob.Inference.AlgorithmW as I (tiType)
-import qualified Blob.Inference.Types as I (Type(..), Scheme(..))
 import Blob.PrettyPrinter.PrettyInference (pType)
 
 program :: Parser Program
@@ -71,18 +69,18 @@ sumType :: Parser Statement
 sumType = do
     string "data"
     name <- typeIdentifier
-    ts <- many (I.TRigidVar <$> typeVariable)
+    ts <- many typeVariable
     string "="
     ctor1 <- constructor name ts
     ctors <- many $ do
         string "|"
         constructor name ts
 
-    pure . TypeDeclaration $ TSum name (Map.fromList (ctor1:ctors))
+    pure . TypeDeclaration name ts $ TSum (Map.fromList (ctor1:ctors))
   where constructor name ts = flip (<?>) "type constructor" $ do
             name' <- typeIdentifier
-            type1 <- optional $ many type'
+            type1 <- optional $ many atype'
             
             case type1 of
-                Nothing -> pure (name', I.Scheme (map (show . pType) ts) (foldl I.TApp (I.TId name) ts))
-                Just cs -> pure (name', I.Scheme (map (show . pType) ts) (foldr (I.TFun . I.tiType) (foldl I.TApp (I.TId name) ts) cs))
+                Nothing -> pure (name', Scheme ts (foldl TApp (TId name) $ map TVar ts))
+                Just cs -> pure (name', Scheme ts (foldr TFun (foldl TApp (TId name) $ map TVar ts) cs))

--- a/src/Blob/Parsing/TypeParser.hs
+++ b/src/Blob/Parsing/TypeParser.hs
@@ -2,6 +2,7 @@
 
 module Blob.Parsing.TypeParser 
 ( type'
+, atype'
 ) where
 
 import Blob.Parsing.Types (Parser, Type(..), Expr(..), Literal(..))

--- a/src/Blob/Parsing/Types.hs
+++ b/src/Blob/Parsing/Types.hs
@@ -3,7 +3,7 @@ module Blob.Parsing.Types
 , Associativity(..) , Fixity(..) , CustomOperator(..) -- Custom operators
 , Parser , ParseState(..)                             -- Global
 , Program(..) , Statement(..)                         -- AST
-, Type(..), CustomType(..)                            -- Types
+, Scheme(..), Type(..), CustomType(..)                -- Types
 ) where
 
 import qualified Data.MultiMap as MMap (MultiMap)
@@ -13,7 +13,6 @@ import Data.Text (Text)
 import Data.Void (Void)
 import Control.Monad.Combinators.Expr (Operator)
 import Control.Monad.State (State)
-import qualified Blob.Inference.Types as I (Scheme(..))
 
 ---------------------------------------------------------------------------------------------
 {- Global -}
@@ -74,20 +73,24 @@ newtype Program = Program [Statement]
 data Statement = Declaration String Type
                | Definition String Expr
                | OpDeclaration String Fixity
-               | TypeDeclaration CustomType
+               | TypeDeclaration String [String] CustomType
                | Empty -- Just a placeholder, when a line is a comment, for example.
     deriving (Eq, Ord, Show)
 
 ---------------------------------------------------------------------------------------------
 {- Types -}
 
+data Scheme = Scheme [String] Type
+    deriving (Eq, Ord, Show)
+
 data Type = TId String            -- Type
           | TTuple [Type]         -- (a, ...)
           | TArrow Expr Type Type -- a ->[n] b -o ...
+          | TFun Type Type
           | TVar String           -- a...
           | TApp Type Type        -- Type a...
           | TList Type            -- [a]
     deriving (Eq, Ord, Show)
 
-data CustomType = TSum String (Map.Map String I.Scheme) | TProd String (String, I.Scheme)
+data CustomType = TSum (Map.Map String Scheme) | TProd String Scheme | TAlias Type
     deriving (Eq, Ord, Show)

--- a/src/Blob/PrettyPrinter/PrettyInference.hs
+++ b/src/Blob/PrettyPrinter/PrettyInference.hs
@@ -1,9 +1,10 @@
 module Blob.PrettyPrinter.PrettyInference
 ( pType
+, pKind
 ) where
 
 import Text.PrettyPrint.Leijen (text, parens, Doc, brackets)
-import Blob.Inference.Types (Type(..))
+import Blob.Inference.Types (Type(..), Kind(..))
 import Data.List (intersperse)
 
 pType :: Type -> Doc
@@ -17,3 +18,7 @@ pType (TTuple ts)     = parens (mconcat . intersperse (text ", ") $ map pType ts
 pType (TList t)       = brackets $ pType t
 pType (TApp t1 t2)    = pType t1 <> text " " <> pType t2
 pType (TId u)         = text u
+
+pKind (KVar id')      = text id'
+pKind KType           = text "*"
+pKind (KArr k1 k2)    = text "(" <> pKind k1 <> text " → " <> pKind k2 <> text ")"

--- a/src/Blob/REPL/Commands.hs
+++ b/src/Blob/REPL/Commands.hs
@@ -25,6 +25,7 @@ commands = [  ":help", ":h", ":?"
            ,  ":quit", ":q"
            ,  ":load", ":l" 
            ,  ":type", ":t"
+           ,  ":kind", ":k"
            ,  ":eval", ":ev"
            , ":reset", ":r"
            ,   ":ast", ":a" ]
@@ -63,6 +64,15 @@ getType = do
         Right _ -> fail "Missing argument “[expr]”"
         Left _  -> GetType <$> (space1' *> anySingle `someTill` eof)
 
+getKind :: Parser Command
+getKind = do
+    space' *> try (hidden (string' "kind" <|> string' "k")) <?> "߷"
+
+    end <- observing . try $ space' *> eof
+    case end of
+        Right _ -> fail "Missing argument “[type]”"
+        Left _  -> GetKind <$> (space1' *> anySingle `someTill` eof)
+
 eval :: Parser Command
 eval = do
     space' *> try (hidden (string' "eval" <|> string' "ev")) <?> "߷"
@@ -84,7 +94,7 @@ ast = do
 command :: Parser Command
 command = do {
         space' *> symbol ":" ;
-        cmd <- observing . try $ choice [help, exit, load, getType, eval, reset, ast] ;
+        cmd <- observing . try $ choice [help, exit, load, getType, getKind, eval, reset, ast] ;
         case cmd of
             Left err ->
                 if "߷" `isInfixOf` parseErrorTextPretty err
@@ -113,6 +123,9 @@ helpCommand = do
 
     setSGR [SetColor Foreground Vivid Magenta] >> putStr "“:type [expr]” “:t [expr]”" >> setSGR [Reset]
         >> setSGR [SetColor Foreground Dull White] >> putStrLn ": get the type of an expression." >> setSGR [Reset]
+
+    setSGR [SetColor Foreground Vivid Magenta] >> putStr "“:kind [type]” “:k [type]”" >> setSGR [Reset]
+        >> setSGR [SetColor Foreground Dull White] >> putStrLn ": get the kind of a type." >> setSGR [Reset]
 
     setSGR [SetColor Foreground Vivid Magenta] >> putStr "“:eval [expr]” “:ev [expr]”" >> setSGR [Reset]
         >> setSGR [SetColor Foreground Dull White] >> putStrLn ": evaluate an expression." >> setSGR [Reset]

--- a/src/Blob/REPL/DefaultEnv.hs
+++ b/src/Blob/REPL/DefaultEnv.hs
@@ -3,7 +3,7 @@
 module Blob.REPL.DefaultEnv where
 
 import Blob.REPL.Types (Value(..), Scope)
-import Blob.Inference.Types (Scheme(..), Type(..))
+import Blob.Inference.Types (Scheme(..), Type(..), Kind(..))
 import qualified Data.Map as Map
 import Text.PrettyPrint.Leijen (text)
 import Control.Monad.Except (throwError)
@@ -67,3 +67,8 @@ defaultDeclContext = Map.fromList [ ("+", Scheme ["a"] $ TFun (TRigidVar "a") (T
 
 defaultDefContext :: Map.Map String Scheme
 defaultDefContext = defaultDeclContext
+
+defaultTypeDeclContext :: Map.Map String Kind
+defaultTypeDeclContext = Map.fromList [ ("Integer", KType)
+                                      , ("Float",   KType)
+                                      , ("String",  KType) ]

--- a/src/Blob/REPL/Types.hs
+++ b/src/Blob/REPL/Types.hs
@@ -12,6 +12,7 @@ import System.Console.Haskeline (InputT)
 import Data.List (intercalate)
 
 data Command = GetType String
+             | GetKind String
              | Help
              | Code String
              | Load String


### PR DESCRIPTION
This pull requests checks for the well-formedness of types, and allows to infer the kind of any algebraic data type. Additional support for GADTs should be possible from what's already implemented. I also prepared the possibility for the user to define type aliases (for now there is just an `undefined` for them, since there is no parser for type aliases this should not be a problem). Types can be used in a function type signature before they are defined, since the type declarations are analyzed beforehand. However, mutually recursive type declarations are yet to be handled. The REPL now features a GHCi-inspired `:kind` command to see the inferred kind of any type.